### PR TITLE
topic:大文字小文字変換サイト開発【エラーメッセージの余白の再調整】

### DIFF
--- a/pbf_alphabet_conversion.html
+++ b/pbf_alphabet_conversion.html
@@ -115,7 +115,7 @@
 
           if (escapedInputValue && !/^[a-zA-Zａ-ｚＡ-Ｚ1-9.｡-ﾟ\-/_!?"'`$&|@＠()=#:;,^<>{}\+\*\~\[\] 　]+$/.test(escapedInputValue)) {
               errorMessageElement.textContent = '注意: アルファベット以外は変換できません。';
-              errorMessageElement.style.padding = '15px, 0';
+              errorMessageElement.style.padding = '5px 0';
           } else {
               errorMessageElement.textContent = "";
           }


### PR DESCRIPTION
・スマホで使用した際にエラーメッセージの背景の薄いオレンジ色の部分の余白が狭かったので調整しました
(前回の修正ではイメージ通りになりませんでした)

※errorMessageElement.style.padding = '5px 0';
5pxと0の間にはカンマは必要ない

#1